### PR TITLE
oskar/task-2-coverage-improvement

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -1,36 +1,70 @@
+/\*
+
+- Licensed to the Apache Software Foundation (ASF) under one or more
+- contributor license agreements. See the NOTICE file distributed with
+- this work for additional information regarding copyright ownership.
+- The ASF licenses this file to You under the Apache License, Version 2.0
+- (the "License"); you may not use this file except in compliance with
+- the License. You may obtain a copy of the License at
+-
+-      https://www.apache.org/licenses/LICENSE-2.0
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+- limitations under the License.
+-
+
 # Report for assignment 3
+
 This is a template for your report. You are free to modify it as needed.
 It is not required to use markdown for your report either, but the report
 has to be delivered in a standard, cross-platform format.
+
 ## Project
+
 Name:
 URL:
 One or two sentences describing it
+
 ## Onboarding experience
+
 Did it build and run as documented?
 See the assignment for details; if everything works out of the box,
 there is no need to write much here. If the first project(s) you picked
 ended up being unsuitable, you can describe the "onboarding experience"
 for each project, along with reason(s) why you changed to a different one.
+
 ## Complexity
+
 1. What are your results for five complex functions?
-* Did all methods (tools vs. manual count) get the same result?
-* Are the results clear?
+
+- Did all methods (tools vs. manual count) get the same result?
+- Are the results clear?
+
 2. Are the functions just complex, or also long?
 3. What is the purpose of the functions?
 4. Are exceptions taken into account in the given measurements?
 5. Is the documentation clear w.r.t. all the possible outcomes?
+
 ## Refactoring
+
 Plan for refactoring complex code:
 Estimated impact of refactoring (lower CC, but other drawbacks?).
 Carried out refactoring (optional, P+):
 git diff ...
+
 ## Coverage
+
 ### Tools
+
 Document your experience in using a "new"/different coverage tool.
 How well was the tool documented? Was it possible/easy/difficult to
 integrate it with your build environment?
+
 ### Your own coverage tool
+
 Show a patch (or link to a branch) that shows the instrumented code to
 gather coverage measurements.
 The patch is probably too long to be copied here, so please add
@@ -38,22 +72,30 @@ the git command that is used to obtain the patch instead:
 git diff ...
 What kinds of constructs does your tool support, and how accurate is
 its output?
+
 ### Evaluation
+
 1. How detailed is your coverage measurement?
 2. What are the limitations of your own tool?
 3. Are the results of your tool consistent with existing coverage tools?
+
 ## Coverage improvement
+
 Show the comments that describe the requirements for the coverage.
 Report of old coverage: [link]
 Report of new coverage: [link]
 Test cases added:
 git diff ...
 Number of test cases added: two per team member (P) or at least four (P+).
+
 ## Self-assessment: Way of working
+
 Current state according to the Essence standard: ...
 Was the self-assessment unanimous? Any doubts about certain items?
 How have you improved so far?
 Where is potential for improvement?
+
 ## Overall experience
+
 What are your main take-aways from this project? What did you learn?
 Is there something special you want to mention here?

--- a/src/test/java/org/apache/commons/imaging/formats/bmp/BmpMoreCoverageTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/bmp/BmpMoreCoverageTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.imaging.formats.bmp;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import org.apache.commons.imaging.Imaging;
+import org.apache.commons.imaging.ImagingException;
+import org.junit.jupiter.api.Test;
+
+public class BmpMoreCoverageTest {
+
+    @Test
+    public void testUnknownCompressionException() throws Exception {
+        // Requirement: The parser must reject BMP files that specify an unknown or unsupported compression method.
+        File file = new File("src/test/resources/data/images/bmp/4/rle4.bmp");
+        byte[] bytes = Files.readAllBytes(file.toPath());
+
+        // Intentionally corrupt the Compression field.
+        bytes[30] = 99; 
+
+        // Pass the corrupted bytes to the parser and assert that it throws our expected Exception.
+        ImagingException ex = assertThrows(ImagingException.class, () -> {
+            Imaging.getBufferedImage(bytes);
+        });
+
+        // Verify the assertion matches the documented requirement.
+        assertTrue(ex.getMessage().contains("Unknown Compression"));
+    }
+
+    @Test
+    public void testInvalidBitmapHeaderSizeException() throws Exception {
+        // Requirement: The parser must reject BMP files with a header size smaller than the standard 40 bytes.
+        File file = new File("src/test/resources/data/images/bmp/4/rle4.bmp");
+        byte[] bytes = Files.readAllBytes(file.toPath());
+
+        // The 'bitmapHeaderSize' field is a 4-byte integer starting at offset 14.
+        // Setting it to 39 will trigger the header size exception.
+        bytes[14] = 39;
+        bytes[15] = 0;
+        bytes[16] = 0;
+        bytes[17] = 0;
+
+        ImagingException ex = assertThrows(ImagingException.class, () -> {
+            Imaging.getBufferedImage(bytes);
+        });
+
+        // Assertion based on the documented requirement
+        assertTrue(ex.getMessage().contains("Invalid/unsupported BMP file"));
+    }
+
+    @Test
+    public void testDataOffsetTooSmallException() throws Exception {
+        // Requirement: The parser must reject BMP files where the image data offset is smaller than the expected header and palette size.
+        // This targets the left side of: if (extraBytes < 0 || extraBytes > bhi.fileSize)
+        File file = new File("src/test/resources/data/images/bmp/4/rle4.bmp");
+        byte[] bytes = Files.readAllBytes(file.toPath());
+
+        // The 'bitmapDataOffset' field is a 4-byte integer starting at offset 10.
+        // Setting it to 0 will cause the extraBytes calculation to be negative.
+        bytes[10] = 0;
+        bytes[11] = 0;
+        bytes[12] = 0;
+        bytes[13] = 0;
+
+        ImagingException ex = assertThrows(ImagingException.class, () -> {
+            Imaging.getBufferedImage(bytes);
+        });
+
+        // Assertion based on the documented requirement
+        assertTrue(ex.getMessage().contains("invalid image data offset"));
+    }
+
+    @Test
+    public void testDataOffsetExceedsFileSizeException() throws Exception {
+        // Requirement: The parser must reject BMP files where the calculated extra bytes padding exceeds the total file size.
+        // This targets the right side of: if (extraBytes < 0 || extraBytes > bhi.fileSize)
+        File file = new File("src/test/resources/data/images/bmp/4/rle4.bmp");
+        byte[] bytes = Files.readAllBytes(file.toPath());
+
+        // Get the actual file size directly from the header (offset 2)
+        int fileSize = (bytes[2] & 0xFF) | ((bytes[3] & 0xFF) << 8) | ((bytes[4] & 0xFF) << 16) | ((bytes[5] & 0xFF) << 24);
+
+        // Set the offset to slightly larger than the file size to avoid integer overflow issues
+        // while guaranteeing that extraBytes > fileSize evaluates to true.
+        int newOffset = fileSize + 1024; 
+        bytes[10] = (byte) (newOffset & 0xFF);
+        bytes[11] = (byte) ((newOffset >> 8) & 0xFF);
+        bytes[12] = (byte) ((newOffset >> 16) & 0xFF);
+        bytes[13] = (byte) ((newOffset >> 24) & 0xFF);
+
+        ImagingException ex = assertThrows(ImagingException.class, () -> {
+            Imaging.getBufferedImage(bytes);
+        });
+
+        // Assertion based on the documented requirement
+        assertTrue(ex.getMessage().contains("invalid image data offset"));
+    }
+}


### PR DESCRIPTION
Added 4 more tests to increase coverage: 

- `testUnknownCompressionException`: The original tests only feed the parser valid compression types. The new test ensures that if a malicious or corrupted BMP claims a compression type outside of the supported subset (like 99), the parser securely aborts rather than attempting to parse garbage data. This turns the default case of the first switch(bhi.compression) green.
- `testInvalidBitmapHeaderSizeException`: The BMP standard dictates a minimum header size (40 bytes for a standard BITMAPINFOHEADER). The existing suite never checks if the parser enforces this rule. The new test proves that a truncated header (39 bytes) is correctly rejected before the parser attempts to read missing data, preventing a potential IndexOutOfBoundsException.
- `testDataOffsetTooSmallException`: The data offset dictates where the actual pixel data begins. If this offset is smaller than the header itself, the file is structurally impossible. The original suite ignores this. The new test directly targets the extraBytes < 0 condition, ensuring the parser catches files that point their data offset backward into the header.
- `testDataOffsetExceedsFileSizeException`: This targets the opposite side of the offset calculation (extraBytes > bhi.fileSize). A file claiming its data starts after the end of the file is corrupt. The new test verifies that the parser protects against reading past the end of the file buffer by catching offsets that exceed the actual file size.

Jacoco coverage: 74% 
DIY tool coverage: 72.92%
```bash
--------------------------------------------------
CUSTOM COVERAGE TOOL REPORT:
Branches Hit: 35 out of 48
Branch Coverage: 72.92%
--------------------------------------------------
```